### PR TITLE
Enable parallel downloads of individual files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parallel-getter 0.1.0 (git+https://github.com/pop-os/parallel-getter)",
  "rayon 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1018,6 +1019,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "parallel-getter"
+version = "0.1.0"
+source = "git+https://github.com/pop-os/parallel-getter#500d2a4bf223fb8c42664edcf19ed92a94f4ad5a"
+dependencies = [
+ "progress-streams 1.0.0 (git+https://github.com/pop-os/progress-streams)",
+ "reqwest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,6 +1130,11 @@ dependencies = [
 name = "procedural-masquerade"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "progress-streams"
+version = "1.0.0"
+source = "git+https://github.com/pop-os/progress-streams#aff10d63e378744d07c37d5b481c857b09ef6c3f"
 
 [[package]]
 name = "quote"
@@ -2211,6 +2227,7 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.36 (registry+https://github.com/rust-lang/crates.io-index)" = "409d77eeb492a1aebd6eb322b2ee72ff7c7496b4434d98b3bf8be038755de65e"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
+"checksum parallel-getter 0.1.0 (git+https://github.com/pop-os/parallel-getter)" = "<none>"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
@@ -2224,6 +2241,7 @@ dependencies = [
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum procedural-masquerade 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9a1574a51c3fd37b26d2c0032b649d08a7d51d4cca9c41bbc5bf7118fa4509d0"
+"checksum progress-streams 1.0.0 (git+https://github.com/pop-os/progress-streams)" = "<none>"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ libc = "0.2"
 libflate = "0.1.18"
 log = { version = "0.4.3" }
 md-5 = "0.7.0"
+parallel-getter = { git = "https://github.com/pop-os/parallel-getter" }
 rayon = "1.0.2"
 regex = "1.0.5"
 reqwest = "0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ extern crate itertools;
 extern crate libc;
 extern crate libflate;
 extern crate md5;
+extern crate parallel_getter;
 extern crate rayon;
 extern crate regex;
 extern crate reqwest;

--- a/src/repo/download/mod.rs
+++ b/src/repo/download/mod.rs
@@ -8,6 +8,7 @@ use self::direct::DownloadResult;
 use std::io;
 use std::path::PathBuf;
 use std::process::exit;
+use std::sync::Arc;
 use reqwest::{self, Client};
 
 pub fn all(config: &Config) {
@@ -75,10 +76,11 @@ pub fn all(config: &Config) {
 // TODO: Optimize with a shrinking queue.
 pub fn packages(sources: &Config, packages: &[&str]) {
     let mut downloaded = 0;
+    let client = Arc::new(Client::new());
 
     if let Some(ref source) = sources.direct.as_ref() {
         for source in source.iter().filter(|s| packages.contains(&s.name.as_str())) {
-            if let Err(why) = direct::download(&Client::new(), source, &sources.archive, &sources.default_component) {
+            if let Err(why) = direct::download(client.clone(), source, &sources.archive, &sources.default_component) {
                 error!("failed to download {}: {}", &source.name, why);
                 exit(1);
             }

--- a/src/repo/download/repos.rs
+++ b/src/repo/download/repos.rs
@@ -97,12 +97,13 @@ pub fn download(repos: &[Repo], suite: &str, component: &str) -> io::Result<()> 
             });
 
             // Main thread fetches packages in parallel
-            let client = Client::new();
+            let client = Arc::new(Client::new());
             *result = out_rx
                 .into_iter()
                 .par_bridge()
                 .map(|(url, compare, dest)| {
-                    request::file(&client, &url, compare, &dest)?;
+                    let client = client.clone();
+                    request::file(client, &url, compare, &dest)?;
                     Ok(())
                 })
                 .collect::<io::Result<()>>();


### PR DESCRIPTION
- Imports our new `parallel-getter` crate to enable parallel transfers of individual files.
- This will enable apt-fast-like transfer speeds.
- Currently set to use 4 threads / requests per file transfer.