### PR TITLE
Cap concurrent file downloads to 8, and shorten request progress lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "parallel-getter"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/parallel-getter#500d2a4bf223fb8c42664edcf19ed92a94f4ad5a"
+source = "git+https://github.com/pop-os/parallel-getter#f7b324f7e6e6a3a51171fc0acc153f0b7f64232b"
 dependencies = [
  "progress-streams 1.0.0 (git+https://github.com/pop-os/progress-streams)",
  "reqwest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/repo/download/request.rs
+++ b/src/repo/download/request.rs
@@ -15,9 +15,10 @@ pub enum RequestCompare<'a> {
     SizeAndModification(u64, Option<i64>)
 }
 
-pub fn file(client: Arc<Client>, url: &str, compare: RequestCompare, path: &Path) -> io::Result<u64> {
+pub fn file(client: Arc<Client>, name: String, url: &str, compare: RequestCompare, path: &Path) -> io::Result<u64> {
     let mut tries = 0;
-    let filename = Arc::new(path.file_name().unwrap().to_str().unwrap().to_owned());
+
+    let name = Arc::new(name);
     loop {
         let mut file = if path.exists() {
             let mut requires_download = true;
@@ -61,12 +62,12 @@ pub fn file(client: Arc<Client>, url: &str, compare: RequestCompare, path: &Path
         };
 
         info!("downloading package to {}", path.display());
-        let filename = filename.clone();
+        let name = name.clone();
         let downloaded = ParallelGetter::new(url, &mut file)
             .client(client.clone())
             .threads(4)
             .callback(3000, Box::new(move |p, t| {
-                info!("{}: downloaded {} out of {} MiB", filename, p / 1024 / 1024, t / 1024 / 1024)
+                info!("{}: downloaded {} out of {} MiB", name, p / 1024 / 1024, t / 1024 / 1024)
             }))
             .get()? as u64;
 

--- a/src/repo/download/request.rs
+++ b/src/repo/download/request.rs
@@ -66,7 +66,7 @@ pub fn file(client: Arc<Client>, name: String, url: &str, compare: RequestCompar
         let downloaded = ParallelGetter::new(url, &mut file)
             .client(client.clone())
             .threads(4)
-            .callback(3000, Box::new(move |p, t| {
+            .callback(3000, Arc::new(move |p, t| {
                 info!("{}: downloaded {} out of {} MiB", name, p / 1024 / 1024, t / 1024 / 1024)
             }))
             .get()? as u64;


### PR DESCRIPTION
- Thread pools will be used to limit concurrent file downloads to 8 files at a time
- The file requester will now use the package name when showing download progress

Example:

```
[INFO] debrep: kicad-dbg: downloaded 288 out of 289 MiB
[INFO] debrep: kicad-packages3d: downloaded 289 out of 299 MiB
```