### PR TITLE
Multi-suite configuration support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,17 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "crossbeam"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -397,7 +417,7 @@ dependencies = [
  "libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parallel-getter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parallel-getter 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1031,9 +1051,10 @@ dependencies = [
 
 [[package]]
 name = "parallel-getter"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "crossbeam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "numtoa 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "progress-streams 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2158,8 +2179,10 @@ dependencies = [
 "checksum core-foundation-sys 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "716c271e8613ace48344f723b60b900a93150271e5be206212d052bbc0883efa"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
 "checksum crossbeam 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24ce9782d4d5c53674646a6a4c1863a21a8fc0cb649b3c94dfc16e45071dea19"
+"checksum crossbeam 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7408247b1b87f480890f28b670c5f8d9a8a4274833433fe74dc0dfd46d33650"
 "checksum crossbeam-channel 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7b85741761b7f160bc5e7e0c14986ef685b7f8bf9b7ad081c60c604bb4649827"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-deque 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7792c4a9b5a4222f654e3728a3dd945aacc24d2c3a1a096ed265d80e4929cb9a"
 "checksum crossbeam-deque 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3486aefc4c0487b9cb52372c97df0a48b8c249514af1ee99703bf70d2f2ceda1"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-epoch 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30fecfcac6abfef8771151f8be4abc9e4edc112c2bcb233314cafde2680536e9"
@@ -2241,7 +2264,7 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.36 (registry+https://github.com/rust-lang/crates.io-index)" = "409d77eeb492a1aebd6eb322b2ee72ff7c7496b4434d98b3bf8be038755de65e"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-"checksum parallel-getter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a8d7e32d5d7129225cae6a955011c14e7ced00775dff65231f8c82b75b7723b"
+"checksum parallel-getter 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de9156f5b45178d136c454baa0f56016b248ea1612a118e1d4c936b8824f7337"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,7 +397,7 @@ dependencies = [
  "libflate 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "md-5 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parallel-getter 0.1.0 (git+https://github.com/pop-os/parallel-getter)",
+ "parallel-getter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -988,6 +988,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "numtoa"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "openssl"
 version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,9 +1032,10 @@ dependencies = [
 [[package]]
 name = "parallel-getter"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/parallel-getter#f7b324f7e6e6a3a51171fc0acc153f0b7f64232b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "progress-streams 1.0.0 (git+https://github.com/pop-os/progress-streams)",
+ "numtoa 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "progress-streams 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1140,7 +1146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "progress-streams"
 version = "1.0.0"
-source = "git+https://github.com/pop-os/progress-streams#aff10d63e378744d07c37d5b481c857b09ef6c3f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -2230,11 +2236,12 @@ dependencies = [
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+"checksum numtoa 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e521b6adefa0b2c1fa5d2abdf9a5216288686fe6146249215d884c0e5ab320b0"
 "checksum openssl 0.10.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5e2e79eede055813a3ac52fb3915caf8e1c9da2dec1587871aec9f6f7b48508d"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.36 (registry+https://github.com/rust-lang/crates.io-index)" = "409d77eeb492a1aebd6eb322b2ee72ff7c7496b4434d98b3bf8be038755de65e"
 "checksum owning_ref 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cdf84f41639e037b484f93433aa3897863b561ed65c6e59c7073d7c561710f37"
-"checksum parallel-getter 0.1.0 (git+https://github.com/pop-os/parallel-getter)" = "<none>"
+"checksum parallel-getter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a8d7e32d5d7129225cae6a955011c14e7ced00775dff65231f8c82b75b7723b"
 "checksum parking_lot 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "f0802bff09003b291ba756dc7e79313e51cc31667e94afbe847def490424cde5"
 "checksum parking_lot_core 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "4db1a8ccf734a7bce794cc19b3df06ed87ab2f3907036b693c68f56b4d4537fa"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
@@ -2248,7 +2255,7 @@ dependencies = [
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum procedural-masquerade 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9a1574a51c3fd37b26d2c0032b649d08a7d51d4cca9c41bbc5bf7118fa4509d0"
-"checksum progress-streams 1.0.0 (git+https://github.com/pop-os/progress-streams)" = "<none>"
+"checksum progress-streams 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "84006a1c44697e5189d10d04926dac90d9b739ab8db0221d0fb4bfd41a2ebd32"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ libc = "0.2"
 libflate = "0.1.18"
 log = { version = "0.4.3" }
 md-5 = "0.7.0"
-parallel-getter = "0.1.0"
+parallel-getter = "0.2.0"
 rayon = "1.0.2"
 regex = "1.0.5"
 reqwest = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ libc = "0.2"
 libflate = "0.1.18"
 log = { version = "0.4.3" }
 md-5 = "0.7.0"
-parallel-getter = { git = "https://github.com/pop-os/parallel-getter" }
+parallel-getter = "0.1.0"
 rayon = "1.0.2"
 regex = "1.0.5"
 reqwest = "0.9"

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The root directory of a debrep-based repo will contain the following directories
   - On build, they'll be generated and placed into the repo.
 - **record/**: keeps tabs on what source packages have been built
 - **repo/**: Contains the archive & associated dist and pool directories for each
-- **sources.toml**: Configuration for the entire repo.
+- **suites/suite-name.toml**: Configuration files for each repo to build.
 
 ## Highly Parallel Distribution File Generation
 
@@ -147,20 +147,4 @@ debrep clean
 ### Remove packages
 ```
 debrep remove <PACKAGES>...
-```
-
-### Pretty-print the sources.toml configuration
-```
-debrep config
-```
-
-### Fetch a field from the configuration file
-```
-debrep config direct.atom-editor.version
-```
-
-### Update a field in the configuration file
-```
-deprep config direct.atom-editor.version ${NEW_VERSION}
-deprep config direct.atom-editor.url ${NEW_URL}
 ```

--- a/src/config/direct.rs
+++ b/src/config/direct.rs
@@ -98,7 +98,6 @@ impl Direct {
                 if extension == "deb" {
                     let base = format!("assets/replace/{}{}/{}/", suite, dst, name);
                     let files = PathBuf::from([&base, "files"].concat());
-                    debug!("{:?} exists?", files);
                     if files.exists() {
                         let replace = PathBuf::from([base.as_str(), filename.as_str()].concat());
                         debug!("setting asset target to {:?}", replace);

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,6 @@ use cli::Action;
 use config::{Config, ConfigFetch};
 use repo::{Packages, Repo};
 use std::{env, fs, io};
-use std::path::{Path, PathBuf};
 use std::process::exit;
 
 pub const SHARED_ASSETS: &str = "assets/share/";
@@ -157,7 +156,7 @@ fn read_configs(matches: &ArgMatches) -> io::Result<()> {
     let base_directory = env::current_dir()?;
     let mut configs = Vec::new();
 
-    for file in fs::read_dir(".")? {
+    for file in fs::read_dir("suites")? {
         let file = match file {
             Ok(file) => file,
             Err(_) => continue
@@ -170,8 +169,7 @@ fn read_configs(matches: &ArgMatches) -> io::Result<()> {
         };
 
         if filename.ends_with(".toml") {
-            let path = file.path();
-            let config = config::parse(path.clone()).map_err(|why| io::Error::new(
+            let config = config::parse(file.path()).map_err(|why| io::Error::new(
                 io::ErrorKind::Other,
                 format!("configuration parsing error: {}", why)
             ))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,10 +50,12 @@ pub mod misc;
 mod repo;
 pub mod url;
 
-use clap::{Arg, App, AppSettings, SubCommand};
+use clap::{Arg, App, AppSettings, ArgMatches, SubCommand};
 use cli::Action;
-use config::ConfigFetch;
+use config::{Config, ConfigFetch};
 use repo::{Packages, Repo};
+use std::{env, fs, io};
+use std::path::{Path, PathBuf};
 use std::process::exit;
 
 pub const SHARED_ASSETS: &str = "assets/share/";
@@ -145,66 +147,100 @@ fn main() {
                 .required(true))
         ).get_matches();
 
-    match config::parse() {
-        Ok(mut sources) => {
-            debug!("Config: {:#?}", sources);
-            match Action::new(&matches) {
-                Action::Build(packages, force) => {
-                    Repo::prepare(sources, Packages::Select(&packages, force))
-                        .download()
-                        .build()
-                        .generate();
-                },
-                Action::Clean => {
-                    Repo::prepare(sources, Packages::All).clean();
-                },
-                Action::Dist => {
-                    Repo::prepare(sources, Packages::All).generate();
-                },
-                Action::Fetch(key) => match sources.fetch(&key) {
-                    Some(value) => println!("{}: {}", key, value),
-                    None => {
-                        error!("config field not found");
-                        exit(1);
-                    }
-                },
-                Action::FetchConfig => println!("sources.toml: {:#?}", &sources),
-                Action::Migrate(packages, from_component, to_component) => {
-                    if let Err(why) = repo::migrate(&sources, &packages, from_component, to_component) {
-                        error!("migration failed: {}", why);
-                        exit(1);
-                    }
-                },
-                Action::Pool => {
-                    Repo::prepare(sources, Packages::All).download();
-                },
-                Action::Remove(packages) => {
-                    Repo::prepare(sources, Packages::Select(&packages, false)).remove();
-                },
-                Action::Update(key, value) => match sources.update(key, value.to_owned()) {
-                    Ok(()) => match sources.write_to_disk() {
-                        Ok(()) => info!("successfully wrote config changes to disk"),
-                        Err(why) => {
-                            error!("failed to write config changes: {}", why);
-                            exit(1);
-                        }
-                    },
-                    Err(why) => {
-                        error!("failed to update {}: {}", key, why);
-                        exit(1);
-                    }
-                },
-                Action::UpdateRepository => {
-                    Repo::prepare(sources, Packages::All)
-                        .download()
-                        .build()
-                        .generate();
-                }
+    if let Err(why) = read_configs(&matches) {
+        eprintln!("failed to apply configs: {}", why);
+        exit(1);
+    }
+}
+
+fn read_configs(matches: &ArgMatches) -> io::Result<()> {
+    let base_directory = env::current_dir()?;
+    let mut configs = Vec::new();
+
+    for file in fs::read_dir(".")? {
+        let file = match file {
+            Ok(file) => file,
+            Err(_) => continue
+        };
+
+        let filename = file.file_name();
+        let filename = match filename.as_os_str().to_str() {
+            Some(filename) => filename,
+            None => continue
+        };
+
+        if filename.ends_with(".toml") {
+            let path = file.path();
+            let config = config::parse(path.clone()).map_err(|why| io::Error::new(
+                io::ErrorKind::Other,
+                format!("configuration parsing error: {}", why)
+            ))?;
+
+            configs.push(config);
+        }
+    }
+
+    for config in configs {
+        apply_config(config, matches);
+        env::set_current_dir(&base_directory)?;
+    }
+
+    Ok(())
+}
+
+fn apply_config(mut config: Config, matches: &ArgMatches) {
+    info!("Building from config at {}", config.path.display());
+    match Action::new(&matches) {
+        Action::Build(packages, force) => {
+            Repo::prepare(config, Packages::Select(&packages, force))
+                .download()
+                .build()
+                .generate();
+        },
+        Action::Clean => {
+            Repo::prepare(config, Packages::All).clean();
+        },
+        Action::Dist => {
+            Repo::prepare(config, Packages::All).generate();
+        },
+        Action::Fetch(key) => match config.fetch(&key) {
+            Some(value) => println!("{}: {}", key, value),
+            None => {
+                error!("config field not found");
+                exit(1);
             }
         },
-        Err(why) => {
-            error!("configuration parsing error: {}", why);
-            exit(1);
+        Action::FetchConfig => println!("{}: {:#?}", config.path.display(), &config),
+        Action::Migrate(packages, from_component, to_component) => {
+            if let Err(why) = repo::migrate(&config, &packages, from_component, to_component) {
+                error!("migration failed: {}", why);
+                exit(1);
+            }
+        },
+        Action::Pool => {
+            Repo::prepare(config, Packages::All).download();
+        },
+        Action::Remove(packages) => {
+            Repo::prepare(config, Packages::Select(&packages, false)).remove();
+        },
+        Action::Update(key, value) => match config.update(key, value.to_owned()) {
+            Ok(()) => match config.write_to_disk() {
+                Ok(()) => info!("successfully wrote config changes to disk"),
+                Err(why) => {
+                    error!("failed to write config changes: {}", why);
+                    exit(1);
+                }
+            },
+            Err(why) => {
+                error!("failed to update {}: {}", key, why);
+                exit(1);
+            }
+        },
+        Action::UpdateRepository => {
+            Repo::prepare(config, Packages::All)
+                .download()
+                .build()
+                .generate();
         }
     }
 }

--- a/src/repo/build/mod.rs
+++ b/src/repo/build/mod.rs
@@ -17,7 +17,6 @@ use super::pool::{mv_to_pool, KEEP_SOURCE};
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
-use std::path::{Path, PathBuf};
 use std::process::exit;
 use subprocess::{self, Exec, Redirection};
 use walkdir::WalkDir;
@@ -100,7 +99,6 @@ fn repackage_binaries(packages: Option<&Vec<Direct>>, suite: &str, component: &s
     if let Some(packages) = packages {
         for package in packages {
             for destinations in package.get_destinations(suite, component).unwrap() {
-                debug!("destinations: {:#?}", destinations);
                 let pool = &destinations.pool;
                 if let Some(&(ref files, ref source_deb)) = destinations.assets.as_ref() {
                     if needs_to_repackage(source_deb, files, pool)? {

--- a/src/repo/build/mod.rs
+++ b/src/repo/build/mod.rs
@@ -17,6 +17,7 @@ use super::pool::{mv_to_pool, KEEP_SOURCE};
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::process::exit;
 use subprocess::{self, Exec, Redirection};
 use walkdir::WalkDir;

--- a/src/repo/download/direct.rs
+++ b/src/repo/download/direct.rs
@@ -21,7 +21,6 @@ pub fn download(client: Arc<Client>, item: &Direct, suite: &str, component: &str
         let checksum = path.checksum.as_ref().map(|x| x.as_str());
         // If the file is to be repackaged, store it in the assets directory, else the pool.
         let target = destination.assets.as_ref().map_or(&destination.pool, |x| &x.1);
-        debug!("download {}? target {:?}", &item.name, target);
         downloaded += request::file(client.clone(), item.name.clone(), &destination.url, RequestCompare::Checksum(checksum), target)?;
     }
 

--- a/src/repo/download/request.rs
+++ b/src/repo/download/request.rs
@@ -65,8 +65,10 @@ pub fn file(client: Arc<Client>, name: String, url: &str, compare: RequestCompar
         let name = name.clone();
         let downloaded = ParallelGetter::new(url, &mut file)
             .client(client.clone())
-            .threads(4)
-            .callback(3000, Arc::new(move |p, t| {
+            .threads(8)
+            .threshold_memory(10 * 1024 * 1024)
+            .threshold_parallel(1024 * 1024)
+            .callback(3000, Box::new(move |p, t| {
                 info!("{}: downloaded {} out of {} MiB", name, p / 1024 / 1024, t / 1024 / 1024)
             }))
             .get()? as u64;

--- a/src/repo/download/request.rs
+++ b/src/repo/download/request.rs
@@ -65,10 +65,10 @@ pub fn file(client: Arc<Client>, name: String, url: &str, compare: RequestCompar
         let name = name.clone();
         let downloaded = ParallelGetter::new(url, &mut file)
             .client(client.clone())
-            .threads(8)
+            .threads(4)
             .threshold_memory(10 * 1024 * 1024)
             .threshold_parallel(1024 * 1024)
-            .callback(3000, Box::new(move |p, t| {
+            .callback(1000, Box::new(move |p, t| {
                 info!("{}: downloaded {} out of {} MiB", name, p / 1024 / 1024, t / 1024 / 1024)
             }))
             .get()? as u64;


### PR DESCRIPTION
The lone `sources.toml` file has been done away with to now offer a `suites` directory for storing toml configs for each suite to be built. No changes were made outside of the location for storing suite configrations. The new layout will be:

```
suites/
    bionic.toml
    cosmic.toml
```

The `parallel-getter` dependency has also been updated to use the version on Crates.io.