### PR TITLE
Update file locations for records, logs, and debian packages to support suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,20 @@ The root directory of a debrep-based repo will contain the following directories
   - **cache/**: files which debrep downloads from external sources, and should be cached between runs
   - **share/**: files that can be shared across packages, and are specified in the TOML config
   - **packages/**: files which are automatically linked to the build before building
-- **build/**: debrep performs all builds within this directory.
+  - **replace/${suite}/${component}/${arch}/package/files/**: Repackage prepackaged archives
+    - **DEBIAN**: control archive files to replace
+    - **data**: data archive files to replace
+- **build/${suite}/**: debrep performs all builds within this directory.
   - Every file is linked / sourced here at build time.
   - After each successful build, files are moved into the repo.
-- **debian/**: contains the debian configuration for each source package that needs one.
+- **debian/${suite}/**: contains the debian configuration for each source package that needs one.
   - The directories within must have the same name as the source package they reference.
   - Each package directory contains the entire contents of the debian directory for that package.
-- **metapackages/**: place your `metapackage.cfg` equivs files in here.
+- **metapackages/${suite/**: place your `metapackage.cfg` equivs files in here.
   - On build, they'll be generated and placed into the repo.
-- **record/**: keeps tabs on what source packages have been built
+- **record/${suite}/**: keeps tabs on what source packages have been built
 - **repo/**: Contains the archive & associated dist and pool directories for each
-- **suites/suite-name.toml**: Configuration files for each repo to build.
+- **suites/${suite}.toml**: Configuration files for each repo to build.
 
 ## Highly Parallel Distribution File Generation
 

--- a/src/repo/build/metapackages.rs
+++ b/src/repo/build/metapackages.rs
@@ -7,7 +7,7 @@ use walkdir::{DirEntry, WalkDir};
 use super::super::pool::{mv_to_pool, ARCHIVES_ONLY};
 
 pub fn generate(suite: &str, component: &str) -> io::Result<()> {
-    let metapackages = &Path::new("metapackages");
+    let metapackages = &Path::new("metapackages").join(suite);
     if !metapackages.exists() {
         return Ok(());
     }
@@ -34,7 +34,7 @@ pub fn generate(suite: &str, component: &str) -> io::Result<()> {
         })
         .collect::<io::Result<()>>()?;
 
-    mv_to_pool("metapackages", suite, component, ARCHIVES_ONLY, None)
+    mv_to_pool(&metapackages, suite, component, ARCHIVES_ONLY, None)
 }
 
 fn is_cfg(entry: &DirEntry) -> bool {

--- a/src/repo/build/mod.rs
+++ b/src/repo/build/mod.rs
@@ -312,7 +312,7 @@ pub fn build(item: &Source, pwd: &Path, suite: &str, component: &str, force: boo
                 })?;
         }
         None => {
-            let debian_path = pwd.join(&["debian/", &item.name, "/"].concat());
+            let debian_path = pwd.join(&["debian/", suite, "/", &item.name, "/"].concat());
             if debian_path.exists() {
                 let project_debian_path = project_directory.join("debian");
                 rsync(&debian_path, &project_debian_path)
@@ -368,7 +368,7 @@ fn pre_flight(
 ) -> Result<(), BuildError> {
     let name = &item.name;
     let build_on = item.build_on.as_ref().map(|x| x.as_str());
-    let record_path = PathBuf::from(["../record/", &name].concat());
+    let record_path = PathBuf::from(["../record/", suite, "/", &name].concat());
 
     enum Record {
         Changelog(String),
@@ -479,7 +479,7 @@ fn sbuild<P: AsRef<Path>>(
     component: &str,
     path: P,
 ) -> Result<(), BuildError> {
-    let log_path = pwd.join(["logs/", &item.name].concat());
+    let log_path = pwd.join(["logs/", suite, "/", &item.name].concat());
     let mut command = Exec::cmd("sbuild")
         .args(&["-v", "--log-external-command-output", "--log-external-command-error", "-d", suite])
         .stdout(Redirection::Merge)

--- a/src/repo/download/mod.rs
+++ b/src/repo/download/mod.rs
@@ -34,7 +34,7 @@ pub fn all(config: &Config) {
     }
 
     if let Some(ref sources) = config.source {
-        for (id, result) in sources::parallel(sources)
+        for (id, result) in sources::parallel(sources, &config.archive)
             .into_iter()
             .enumerate()
         {
@@ -94,7 +94,7 @@ pub fn packages(sources: &Config, packages: &[&str]) {
 
     if let Some(ref source) = sources.source.as_ref() {
         for source in source.iter().filter(|s| packages.contains(&s.name.as_str())) {
-            if let Err(why) = sources::download(source) {
+            if let Err(why) = sources::download(source, &sources.archive) {
                 error!("failed to download source {}: {}", &source.name, why);
                 exit(1);
             }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -28,7 +28,7 @@ pub struct Repo<'a> {
 
 impl<'a> Repo<'a> {
     pub fn prepare(config: Config, packages: Packages<'a>) -> Repo<'a> {
-        if let Err(why) = prepare::create_missing_directories() {
+        if let Err(why) = prepare::create_missing_directories(&config.archive) {
             error!("unable to create directories in current directory: {}", why);
             exit(1);
         }

--- a/src/repo/prepare.rs
+++ b/src/repo/prepare.rs
@@ -9,10 +9,14 @@ pub const CACHED_ASSETS: &str = "assets/cache/";
 pub const SHARED_ASSETS: &str = "assets/share/";
 pub const PACKAGE_ASSETS: &str = "assets/packages/";
 
-pub fn create_missing_directories() -> io::Result<()> {
-    [CACHED_ASSETS, SHARED_ASSETS, PACKAGE_ASSETS, "build", "record", "sources", "logs"].iter()
+pub fn create_missing_directories(suite: &str) -> io::Result<()> {
+    let record = ["record/", suite].concat();
+    let logs = ["logs/", suite].concat();
+    [CACHED_ASSETS, SHARED_ASSETS, PACKAGE_ASSETS, "build", &record, &logs].iter()
         .map(|dir| if Path::new(dir).exists() { Ok(()) } else { fs::create_dir_all(dir) })
         .collect::<io::Result<()>>()
+
+    
 }
 
 pub fn package_cleanup(config: &Config) -> io::Result<()> {
@@ -31,7 +35,7 @@ pub fn package_cleanup(config: &Config) -> io::Result<()> {
         for source in sources {
             if source.retain != 0 {
                 if let Some("changelog") = source.build_on.as_ref().map(|x| x.as_str()) {
-                    let cpath = PathBuf::from(["debian/", &source.name, "/changelog"].concat());
+                    let cpath = PathBuf::from(["debian/", &config.archive, "/", &source.name, "/changelog"].concat());
                     if cpath.exists() {
                         let keep = changelog(&cpath, source.retain)?;
                         for (file, version) in locate_files(&source.name, &config.archive) {

--- a/src/repo/prepare.rs
+++ b/src/repo/prepare.rs
@@ -12,11 +12,10 @@ pub const PACKAGE_ASSETS: &str = "assets/packages/";
 pub fn create_missing_directories(suite: &str) -> io::Result<()> {
     let record = ["record/", suite].concat();
     let logs = ["logs/", suite].concat();
-    [CACHED_ASSETS, SHARED_ASSETS, PACKAGE_ASSETS, "build", &record, &logs].iter()
+    let build = ["build/", suite].concat();
+    [CACHED_ASSETS, SHARED_ASSETS, PACKAGE_ASSETS, &build, &record, &logs].iter()
         .map(|dir| if Path::new(dir).exists() { Ok(()) } else { fs::create_dir_all(dir) })
         .collect::<io::Result<()>>()
-
-    
 }
 
 pub fn package_cleanup(config: &Config) -> io::Result<()> {


### PR DESCRIPTION
**Currently testing locally**

- Built source packages will now be recorded at `/records/${suite}/package-name`
- Builds now occur at `/build/${suite}/`
- Metapackages are now moved to `/metapackages/${suite}/`
- Package logs will be retained for each suite at `/logs/${suite}/package-name`
- Debian packaging data will now be separated at `/debian/${suite}/package-name`

This will fix source builds on cosmic so that the CUDA packages will build on both bionic and cosmic separately.