### PR TITLE
Select the correct package versions

### DIFF
--- a/src/repo/pool.rs
+++ b/src/repo/pool.rs
@@ -43,7 +43,6 @@ fn pool<F: Fn(&Path, &Path) -> io::Result<()>>(
     for entry in path.read_dir()? {
         let entry = entry?;
         let path = entry.path();
-        eprintln!("found {}", path.display());
         if path.is_dir() || (flags & ARCHIVES_ONLY != 0 && !is_archive(&path)) {
             continue;
         }


### PR DESCRIPTION
When generating dist files, older versions were getting picked up instead of new versions. This will use the version comparison function that the repo fetching config also uses, so that `10.0` is considered newer than `9.2`.