### PR TITLE
Add missing Multi-Arch field

### DIFF
--- a/src/debian/dist_files/package.rs
+++ b/src/debian/dist_files/package.rs
@@ -52,6 +52,7 @@ impl PackageEntry {
         optional_map!("Package-Type");
         write_from_map!("Architecture");
         write_from_map!("Version");
+        optional_map!("Multi-Arch");
         optional_map!("Auto-Built-Package");
         write_from_map!("Priority");
         write_from_map!("Section");


### PR DESCRIPTION
This will stop the metapackages from giving endless update messages.