### PR TITLE
Support building deb packages from .dsc, fetching git branches and commits, & appending git commit revisions to git-based packages

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -210,5 +210,6 @@ pub fn parse(path: PathBuf) -> Result<Config, ParsingError> {
             }
         }
     }
+
     Ok(config)
 }

--- a/src/config/source.rs
+++ b/src/config/source.rs
@@ -32,6 +32,7 @@ pub enum SourceLocation {
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct Source {
     pub name:             String,
+    pub version:          Option<String>,
     pub location:         Option<SourceLocation>,
     pub assets:           Option<Vec<SourceAsset>>,
     pub starting_build:   Option<Vec<String>>,

--- a/src/config/source.rs
+++ b/src/config/source.rs
@@ -12,15 +12,21 @@ pub struct SourceAsset {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum DebianPath {
+    /// Fetches the debian directory from a separate URL.
     URL { url: String, checksum: String },
+    /// Fetches the debian directory from a separate branch.
     Branch { url: String, branch: String }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum SourceLocation {
+    /// Fetch the source from a remote tarball.
     URL { url: String, checksum: String },
-    Git { git: String, branch: Option<String> },
+    /// Fetch the source by the git repository where it can be reached.
+    Git { git: String, branch: Option<String>, commit: Option<String> },
+    /// Fetch the source by an existing remote debian `.dsc` file.
+    Dsc { dsc: String }
 }
 
 #[derive(Debug, Deserialize, Clone, Serialize)]

--- a/src/repo/build/extract.rs
+++ b/src/repo/build/extract.rs
@@ -39,7 +39,7 @@ fn untar(path: &Path, dst: &Path) -> io::Result<()> {
 
     fs::create_dir_all(dst)
         .and_then(|_| Command::new("tar")
-            .arg("-xf")
+            .arg("-pxf")
             .arg(path)
             .arg("-C")
             .arg(dst)

--- a/src/repo/download/mod.rs
+++ b/src/repo/download/mod.rs
@@ -113,6 +113,8 @@ pub enum DownloadError {
     Open { file: PathBuf, why: io::Error },
     #[fail(display = "checksum for {} is invalid -- expected {}, but received {}", name, expected, received)]
     ChecksumInvalid { name: String, expected: String, received: String },
+    #[fail(display = "failed to fetch remote files via dget for {}: {}", url, why)]
+    DGet { url: String, why: io::Error },
     #[fail(display = "git exited with an error: {}", why)]
     GitFailed { why: io::Error },
     #[fail(display = "failed to request data for {}: {}", name, why)]

--- a/src/repo/download/sources.rs
+++ b/src/repo/download/sources.rs
@@ -110,6 +110,14 @@ fn download_git(name: &str, url: &str, suite: &str, branch: &Option<String>, com
     };
 
     let reset = || -> io::Result<()> {
+        Command::new("git")
+            .arg("-C")
+            .arg(&path_with_name)
+            .args(&["reset", "--hard"])
+            .run()
+    };
+
+    let reset_commit = || -> io::Result<()> {
         if let Some(commit) = commit {
             Command::new("git")
                 .arg("-C")
@@ -136,6 +144,7 @@ fn download_git(name: &str, url: &str, suite: &str, branch: &Option<String>, com
     };
 
     if path_with_name.exists() {
+        reset()?;
         let branch = checkout()?;
 
         if let Some(commit) = commit {
@@ -151,11 +160,11 @@ fn download_git(name: &str, url: &str, suite: &str, branch: &Option<String>, com
         }
 
         pull(branch)?;
-        reset()?;
+        reset_commit()?;
     } else {
         clone()?;
         checkout()?;
-        reset()?;
+        reset_commit()?;
     }
 
     Ok(())

--- a/src/repo/download/sources.rs
+++ b/src/repo/download/sources.rs
@@ -6,7 +6,7 @@ use rayon::ThreadPoolBuilder;
 use reqwest;
 use sha2::Sha256;
 use std::fs::{self, File};
-use std::io;
+use std::{env, io};
 use std::path::PathBuf;
 use super::DownloadError;
 
@@ -23,15 +23,17 @@ pub fn parallel(items: &[Source], suite: &str) -> Vec<Result<(), DownloadError>>
 
 pub fn download(item: &Source, suite: &str) -> Result<(), DownloadError> {
     match item.location {
-        Some(SourceLocation::Git { ref git, ref branch }) => {
-            match *branch {
-                Some(ref _branch) => unimplemented!(),
-                None => download_git(git, suite).map_err(|why| DownloadError::GitFailed { why })
-            }
+        Some(SourceLocation::Git { ref git, ref branch, ref commit }) => {
+            download_git(git, suite, branch, commit).map_err(|why| DownloadError::GitFailed { why })
         },
         Some(SourceLocation::URL { ref url, ref checksum }) => {
             download_(item, url, checksum)
         },
+        Some(SourceLocation::Dsc { ref dsc }) => {
+            download_dsc(item, dsc, suite).map_err(|why| {
+                DownloadError::DGet { url: dsc.to_owned(), why }
+            })
+        }
         None => Ok(())
     }
 }
@@ -85,25 +87,95 @@ fn download_(item: &Source, url: &str, checksum: &str) -> Result<(), DownloadErr
 }
 
 /// Downloads the source repository via git, then attempts to build it.
-fn download_git(url: &str, suite: &str) -> io::Result<()> {
+///
+/// - If the build directory does not exist, it will be cloned.
+/// - Otherwise, the sources will be pulled from the build directory.
+fn download_git(url: &str, suite: &str, branch: &Option<String>, commit: &Option<String>) -> io::Result<()> {
     let name: String = {
         url.split_at(url.rfind('/').unwrap() + 1)
             .1
             .replace(".git", "")
     };
 
-    let path = PathBuf::from(["build/", suite, "/", &name].concat());
+    let path = env::current_dir()
+        .expect("failed to get current directory")
+        .join(["build/", suite].concat());
 
-    if path.exists() {
-        info!("pulling {}", name);
+    let path_with_name = path.join(&name);
+
+    let clone = || -> io::Result<()> {
+        Command::new("git").arg("-C").arg(&path).args(&["clone", &url]).run()
+    };
+
+    let pull = |branch: &str| -> io::Result<()> {
         Command::new("git")
             .arg("-C")
-            .arg(&path)
-            .args(&["pull", "origin", "master"])
+            .arg(&path_with_name)
+            .args(&["pull", "origin", branch])
             .run()
+    };
+
+    let reset = || -> io::Result<()> {
+        if let Some(commit) = commit {
+            Command::new("git")
+                .args(&["reset", "--hard", &commit])
+                .run()?;
+        }
+
+        Ok(())
+    };
+
+    let checkout = || -> io::Result<&str> {
+        match branch {
+            Some(branch) => {
+                Command::new("git").args(&["checkout", &branch]).run()?;
+                Ok(branch.as_str())
+            }
+            None => Ok("master")
+        }
+    };
+
+    if path_with_name.exists() {
+        let branch = checkout()?;
+
+        if let Some(commit) = commit {
+            let current_revision = Command::new("git")
+                .args(&["rev-parse", branch])
+                .run_with_stdout()?;
+
+            if current_revision.starts_with(commit.as_str()) {
+                return Ok(());
+            }
+        }
+
+        pull(branch)?;
+        reset()?;
     } else {
-        info!("cloning {}", name);
-        let path = ["build/", suite].concat();
-        Command::new("git").args(&["-C", &path, "clone", &url]).run()
+        clone()?;
+        checkout()?;
+        reset()?;
     }
+
+    Ok(())
+}
+
+/// Downloads a debian package's sources from the given remote `dsc` URL.
+///
+/// - The files will only be downloaded, not extracted.
+/// - The files will only be downloaded if they do not already exist.
+fn download_dsc(item: &Source, dsc: &str, suite: &str) -> io::Result<()> {
+    let path = PathBuf::from(["build/", suite, "/", &item.name].concat());
+    let mut result = Ok(());
+    if ! path.join(::misc::filename_from_url(dsc)).exists() {
+        fs::create_dir_all(&path)?;
+        let cwd = env::current_dir()?;
+        env::set_current_dir(&path)?;
+
+        result = Command::new("dget").args(&["-uxqd", dsc]).run();
+        if let Err(why) = env::set_current_dir(cwd) {
+            panic!("failed to set directory to original location: {}", why);
+        }
+    }
+
+    result
 }


### PR DESCRIPTION
Closes #33 

- dsc files may now be specified as a possible source location variant
- The git source location variant now supports specifying a branch and commit
- Enable automatic changelog updates of git sources, to append the commit to the changelog

### Example

```
[DEBUG] debrep: running "git" "-C" "/home/mmstick/Sources/repo-curated-free/build/cosmic/piserver" "rev-parse" "master"
[DEBUG] debrep: running "dch" "-D" "cosmic" "-l" "~40a78a" "-c" "/home/mmstick/Sources/repo-curated-free/build/cosmic/piserver/debian/changelog" "automatic build of commit 40a78a"
[INFO] debrep: building piserver at changelog version 0.3~40a78a1
```

```
building ion-shell at changelog version 1.0.0-alpha0-cosmic2~0bff9e1
```

```toml
[[source]]
name = "ion-shell"
version = "1.0.0-alpha0-cosmic2"

    [source.location]
    dsc = "https://launchpad.net/~mmstick76/+archive/ubuntu/${name}/+sourcefiles/${name}/${version}/${name}_${version}.dsc"
```

```toml
[[source]]
name = "ion-shell"
build_on = "changelog"

    [source.location]
    git = "https://gitlab.redox-os.org/redox-os/ion/"
    branch = "master"
    commit = "0bff9e12"
```