### PR TITLE
Handle shared assets that are directories

### DIFF
--- a/src/misc.rs
+++ b/src/misc.rs
@@ -115,7 +115,7 @@ pub fn unlink(link: &Path) -> io::Result<()> {
 }
 
 pub fn get_arch_from_stem(stem: &str) -> &str {
-    if let Some(arch) = ["amd64", "i386"].into_iter().find(|&x| stem.ends_with(x)) {
+    if let Some(arch) = ["amd64", "i386"].iter().find(|&x| stem.ends_with(x)) {
         return arch;
     }
 

--- a/src/repo/build/mod.rs
+++ b/src/repo/build/mod.rs
@@ -251,13 +251,21 @@ fn fetch_assets(
         if path.is_dir() {
             let relative = path.strip_prefix(src).unwrap();
             let new_path = dst.join(relative);
-            if !new_path.exists() {
-                fs::create_dir(&new_path)
+            if ! new_path.exists() {
+                fs::create_dir_all(&new_path)
                     .map_err(|why| BuildError::Directory { path: new_path, why })?;
             }
         } else {
             let relative = path.strip_prefix(src).unwrap();
-            let dst = dst.join(relative);
+
+            let dst_: PathBuf;
+            let dst = if relative.as_os_str().is_empty() {
+                dst
+            } else {
+                dst_ = dst.join(relative);
+                &dst_
+            };
+
             let src = path.canonicalize().unwrap();
             linked.push(link_artifact(&src, &dst)?);
         }
@@ -305,39 +313,6 @@ pub fn build(config: &Config, item: &Source, pwd: &Path, suite: &str, component:
     let mut linked: Vec<LinkedArtifact> = Vec::new();
 
     if dsc_file.is_none() {
-        match pwd.join(&["assets/packages/", &item.name].concat()) {
-            ref local_assets if local_assets.exists() => {
-                fetch_assets(&mut linked, local_assets, &project_directory)?;
-            },
-            _ => ()
-        }
-
-        if let Some(ref assets) = item.assets {
-            if ! project_directory.exists() {
-                fs::create_dir_all(&project_directory);
-            }
-
-            for asset in assets {
-                if let Ok(globs) = glob(&[SHARED_ASSETS, &asset.src].concat()) {
-                    for file in globs.flat_map(|x| x.ok()) {
-                        // If the asset source is a directory, the filename of that directory
-                        // will be appended to the destionation path.
-                        let tmp: PathBuf;
-                        let dst = if file.is_dir() {
-                            tmp = asset.dst.join(file.file_name().unwrap());
-                            &tmp
-                        } else {
-                            &asset.dst
-                        };
-
-                        // Then the destination will point to the build directory for this package.
-                        let dst = project_directory.join(&dst);
-                        fetch_assets(&mut linked, &file, &dst)?;
-                    }
-                }
-            }
-        }
-
         match item.debian {
             Some(DebianPath::URL { ref url, ref checksum }) => {
                 unimplemented!()
@@ -353,7 +328,7 @@ pub fn build(config: &Config, item: &Source, pwd: &Path, suite: &str, component:
             None => {
                 let debian_path = pwd.join(&["debian/", suite, "/", &item.name, "/"].concat());
                 if debian_path.exists() {
-                    let project_debian_path = project_directory.join("debian");
+                    let project_debian_path = project_directory.join("debian/");
                     rsync(&debian_path, &project_debian_path)
                         .map_err(|why| BuildError::Rsync {
                             src: debian_path,
@@ -366,6 +341,41 @@ pub fn build(config: &Config, item: &Source, pwd: &Path, suite: &str, component:
                             path: project_debian_path,
                             why
                         })?;
+                }
+            }
+        }
+
+        match pwd.join(&["assets/packages/", &item.name].concat()) {
+            ref local_assets if local_assets.exists() => {
+                fetch_assets(&mut linked, local_assets, &project_directory)?;
+            },
+            _ => ()
+        }
+
+        if let Some(ref assets) = item.assets {
+            for asset in assets {
+                if let Ok(globs) = glob(&[SHARED_ASSETS, &asset.src].concat()) {
+                    for file in globs.flat_map(|x| x.ok()) {
+                        // If the asset source is a directory, the filename of that directory
+                        // will be appended to the destionation path.
+                        let tmp: PathBuf;
+                        let dst = if file.is_dir() {
+                            tmp = asset.dst.join(file.file_name().unwrap());
+                            &tmp
+                        } else {
+                            &asset.dst
+                        };
+
+                        // Then the destination will point to the build directory for this package.
+                        let dst = project_directory.join(&dst);
+                        if let Some(parent) = dst.parent() {
+                            if ! parent.exists() {
+                                fs::create_dir_all(&parent);
+                            }
+                        }
+
+                        fetch_assets(&mut linked, &file, &dst)?;
+                    }
                 }
             }
         }

--- a/src/repo/build/rsync.rs
+++ b/src/repo/build/rsync.rs
@@ -5,12 +5,12 @@ use std::{io, fs};
 pub fn rsync(src: &Path, dst: &Path) -> io::Result<()> {
     info!("rsyncing {} to {}", src.display(), dst.display());
 
-    if src.is_dir() {
+    if src.is_dir() && ! dst.exists() {
         fs::create_dir_all(dst).map_err(|why| io::Error::new(
             io::ErrorKind::Other,
             format!("failed to create destination directory at {:?} for rsync: {}", dst, why)
         ))?;
     }
 
-    Command::new("rsync").arg("-avz").arg(src).arg(dst).run()
+    Command::new("rsync").args(&["--ignore-existing", "-avz"]).arg(src).arg(dst).run()
 }


### PR DESCRIPTION
This will be used to trim down the LOC required for packaging tensorflow in the cuda repository.