### PR TITLE
support multi-architecture cross-compiling

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -47,6 +47,8 @@ pub struct Config {
     pub origin: String,
     pub label: String,
     pub email: String,
+    #[serde(default = "default_architectures")]
+    pub architectures: Vec<String>,
     /// Packages which are already in the deb format.
     pub direct: Option<Vec<Direct>>,
     /// Projects which can be built from source.
@@ -92,6 +94,9 @@ impl Config {
     }
 }
 
+fn default_architectures() -> Vec<String> {
+    vec!["amd64".into(), "i368".into()]
+}
 fn default_component() -> String { "main".into() }
 
 /// Methods for fetching and updating values from the in-memory representation of the TOML spec.

--- a/src/debian/dist_files/mod.rs
+++ b/src/debian/dist_files/mod.rs
@@ -69,7 +69,15 @@ impl<'a> DistFiles<'a> {
                 || {
                     let arch_dir = match arch {
                         "amd64" => "binary-amd64",
+                        "arm64" => "binary-arm64",
+                        "armel" => "binary-armel",
+                        "armhf" => "binary-armhf",
                         "i386" => "binary-i386",
+                        "mips" => "binary-mips",
+                        "mipsel" => "binary-mipsel",
+                        "mips64el" => "binary-mips64el",
+                        "ppc64el" => "binary-ppc64el",
+                        "s390x" => "binary-s390x",
                         "all" => "binary-all",
                         arch => panic!("unsupported architecture: {}", arch),
                     };

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -11,6 +11,10 @@ use walkdir::{DirEntry, WalkDir};
 pub const INCLUDE_DDEB: u8 = 1;
 pub const INCLUDE_SRCS: u8 = 2;
 
+pub static ARCHITECTURES: [&str; 10] = [
+    "amd64", "i386", "arm64", "armel", "armhf", "mips", "mipsel", "mips64el", "ppc64el", "s390x",
+];
+
 pub fn filename_from_url(url: &str) -> &str {
     &url[url.rfind('/').map_or(0, |x| x + 1)..]
 }
@@ -115,7 +119,7 @@ pub fn unlink(link: &Path) -> io::Result<()> {
 }
 
 pub fn get_arch_from_stem(stem: &str) -> &str {
-    if let Some(arch) = ["amd64", "i386"].iter().find(|&x| stem.ends_with(x)) {
+    if let Some(arch) = ARCHITECTURES.iter().find(|&x| stem.ends_with(x)) {
         return arch;
     }
 

--- a/src/repo/build/mod.rs
+++ b/src/repo/build/mod.rs
@@ -542,7 +542,10 @@ fn pre_flight(
         None => dir
     };
 
-    sbuild(config, item, &pwd, suite, component, dir)?;
+    config
+        .architectures
+        .iter()
+        .try_for_each(|arch| sbuild(config, item, &pwd, suite, component, dir, arch))?;
 
     let result = match record {
         Some(Record::Dsc(dsc)) => {
@@ -574,11 +577,13 @@ fn sbuild<P: AsRef<Path>>(
     suite: &str,
     component: &str,
     path: P,
+    arch: &str,
 ) -> Result<(), BuildError> {
     let log_path = pwd.join(["logs/", suite, "/", &item.name].concat());
     let mut command = Exec::cmd("sbuild")
         .args(&[
             "-v", "--log-external-command-output", "--log-external-command-error",
+            &format!("--host={}", arch),
             // "--dpkg-source-opt=-Zgzip", // Use this when testing
             "-d", suite
         ])

--- a/src/repo/build/mod.rs
+++ b/src/repo/build/mod.rs
@@ -579,7 +579,7 @@ fn sbuild<P: AsRef<Path>>(
     path: P,
     arch: &str,
 ) -> Result<(), BuildError> {
-    let log_path = pwd.join(["logs/", suite, "/", &item.name].concat());
+    let log_path = pwd.join(["logs/", suite, "/", &format!("{}-{}", item.name, arch)].concat());
     let mut command = Exec::cmd("sbuild")
         .args(&[
             "-v", "--log-external-command-output", "--log-external-command-error",

--- a/src/repo/generate.rs
+++ b/src/repo/generate.rs
@@ -167,7 +167,15 @@ fn binary_suites(pool_base: &Path) -> io::Result<Vec<(String, PathBuf)>> {
                 let path = pool_base.join(&arch);
                 let arch = match arch.to_str().unwrap() {
                     "binary-amd64" => "amd64",
+                    "binary-arm64" => "arm64",
+                    "binary-armel" => "armel",
+                    "binary-armhf" => "armhf",
                     "binary-i386" => "i386",
+                    "binary-mips" => "mips",
+                    "binary-mipsel" => "mipsel",
+                    "binary-mips64el" => "mips64el",
+                    "binary-ppc64el" => "ppc64el",
+                    "binary-s390x" => "s390x",
                     "binary-all" => "all",
                     arch => panic!("unsupported architecture: {}", arch),
                 };

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -181,7 +181,20 @@ fn collect_components(pool: &Path, base: &str) -> io::Result<Vec<String>> {
             if component.path().is_dir() {
                 let component = component.file_name();
                 let component = component.to_str().unwrap();
-                for arch in &["binary-amd64", "binary-i386", "binary-all", "source"] {
+                for arch in &[
+                    "binary-amd64",
+                    "binary-arm64",
+                    "binary-armel",
+                    "binary-armhf",
+                    "binary-i386",
+                    "binary-mips",
+                    "binary-mipsel",
+                    "binary-mips64el",
+                    "binary-ppc64el",
+                    "binary-s390x",
+                    "binary-all",
+                    "source",
+                ] {
                     let _ = fs::create_dir_all([&base, "/", component, "/", arch].concat());
                 }
 


### PR DESCRIPTION
hi @mmstick, first up thanks for a sweet tool for Debian packaging! :100: 

i'd like to use `debrep` for building Debian packages for a project [PeachCloud](https://peachcloud.org/) :peach: :cloud: , which will run on (Raspberry Pi) ARM devices, so i'm keen to add cross-compilation support to `deprep`.

here's a pull request that seems to work:

- adds `architectures` field to suite config, which defaults to [`amd64`, `i386`]
- runs `sbuild` for each architecture (in a `iter.try_for_each`)
- architecture matches support all official Debian architectures: https://www.debian.org/ports/

here's a demo using this to build a basic Rust package for `amd64`, `i386`, `arm64`, and `armhf`: https://github.com/peachcloud/peach-packages.

happy to implement this feature however you want, let me know if anything is not okay, or if you want something done differently, or if i'm missing a better way to do this, etc. i kept the changes pretty minimal to get it working and start the conversation, but for example at the moment this compiles every architecture in series _and then_ writes the record object without any architecture information, maybe you have a better idea.

cheers! :smiley_cat: 