### PR TITLE
fix: Correct logging option syntax

### DIFF
--- a/src/repo/build/mod.rs
+++ b/src/repo/build/mod.rs
@@ -666,7 +666,7 @@ fn sbuild<P: AsRef<Path>>(
         .args(&[
             "-v",
             "--log-external-command-output",
-            "--log-external-command-log::error",
+            "--log-external-command-error",
             &format!("--host={}", arch),
             // "--dpkg-source-opt=-Zgzip", // Use this when testing
             "-d",


### PR DESCRIPTION
The build's currently failing on:

```
# sbuild -v --log-external-command-output '--log-external-command-log::error' '--host=amd64' -d jammy '--extra-repository-key=/extra/apt-proprietary/build/keys/system76-pop.asc' /extra/apt-proprietary/build/build/jammy/natron
Unknown option: log-external-command-log::error
E: Error parsing command-line options
I: Run 'sbuild --help' to list usage example and all available options
```

I believe `--log-external-command-log::error` is a typo (introduced in 53e52fb1a2cf05860536feee525ef3794fa7d730). https://manpages.debian.org/bookworm/sbuild/sbuild.conf.5.en.html#LOG_EXTERNAL_COMMAND_ERROR lists the option as `--log-external-command-error`. (`log::error!` is a Rust macro.)